### PR TITLE
Add missing LDFLAGS to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test:
 targets: fvcbm fvcbm.man
 
 fvcbm:	fvcbm.o cbmarcs.o
-	$(CC) $(CFLAGS) -o $@ fvcbm.o cbmarcs.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ fvcbm.o cbmarcs.o
 
 cbmarcs.o:	cbmarcs.c cbmarcs.h
 	$(CC) $(CFLAGS) $(PACKFLAG) -c $<


### PR DESCRIPTION
Makefile is currently not using LDFLAGS.